### PR TITLE
fix(auth): fix the crash in manual login

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -52,7 +52,7 @@ async function executeAutoStrategy(page, loginUrl) {
 async function executeManualStrategy() {
     console.log(`[INFO] (auth): Please enter your password in your browser and take the Turnstile test. Click "Login" and wait until you see the dashboard.`);
     console.log(`[INFO] (auth): Once fully logged in, return here and press ENTER.`);
-    await waitAndAsk('[ACTION REQUIRED]: Press ENTER if you are logged in successfully...');
+    await promptUser('[ACTION REQUIRED]: Press ENTER if you are logged in successfully...');
 }
 
 async function performAuthentication(mode) {


### PR DESCRIPTION
This PR fixes an error in manual login systems where an old function name from the legacy code couldn't be found, causing the code to crash.

- The function formerly known as `waitAndAsk` was renamed `promptUser` in the last update, but the code was crashing because the call within the code wasn't updated; this issue has been fixed.

This is a **hotfix**. Updating is recommended.

Fixes #3 