### PR TITLE
feat(api): add the auth system to authenticate requests with an API key

### DIFF
--- a/src/config.js.example
+++ b/src/config.js.example
@@ -1,6 +1,9 @@
 module.exports = {
     PORT: process.env.PORT || 3001,
 
+    USE_API_KEY: true,
+    API_KEY: 'FkZNpN08O0s0OEWZALNrRsXtIHsi2WKFEoHpANX3uVf', // example api key
+
     LOGIN_MODE: 'auto', // auto or manual
     USERNAME: '1234',
     PASSWORD: 'P@ssw0rd!',

--- a/src/middleware/apiAuth.js
+++ b/src/middleware/apiAuth.js
@@ -1,0 +1,22 @@
+const config = require('../config');
+
+function apiKeyMiddleware(req, res, next) {
+    
+    if (!config.USE_API_KEY) {
+        return next();
+    }
+
+    const providedKey = req.headers['x-api-key'];
+
+    if (!providedKey || providedKey !== config.API_KEY) {
+        console.log(`[WARN] (apiAuth): Unauthorized access. IP: ${req.ip}`);
+        return res.status(401).json({
+            success: false,
+            message: 'Unauthorized access. You must provide a valid x-api-key header.'
+        });
+    }
+
+    next();
+}
+
+module.exports = apiKeyMiddleware;

--- a/src/server.js
+++ b/src/server.js
@@ -2,9 +2,12 @@ const express = require('express');
 const { runScraper } = require('./core/scraperEngine');
 const scrapers = require('./scrapers');
 const { generateIcsFromTimetable } = require('./utils/icsGenerator'); 
+const apiKeyMiddleware = require('./middleware/apiAuth');
 
 const app = express();
 app.use(express.json());
+
+app.use(apiKeyMiddleware); // API KEY CONTROL
 
 app.get('/api/scrape/:taskId/ics', async (req, res) => {
     const { taskId } = req.params;


### PR DESCRIPTION
This PR adds the ability to authenticate with an API key in order to retrieve data from API endpoints.


- Create an API key in the `config.js` file and enable API authentication.
```javascript
USE_API_KEY: true,
API_KEY: 'FkZNpN08O0s0OEWZALNrRsXtIHsi2WKFEoHpANX3uVf', // example key
```
- Now, if there is no valid `x-api-key` value in the http headers, the system will return a `401` response.


Please check the updated sample config file (`config.js.example`).