### PR TITLE
feat(api): add metadata block to API outputs

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -4,6 +4,8 @@ const scrapers = require('./scrapers');
 const { generateIcsFromTimetable } = require('./utils/icsGenerator'); 
 const apiKeyMiddleware = require('./middleware/apiAuth');
 
+const { successResponse, errorResponse } = require('./utils/response');
+
 const app = express();
 app.use(express.json());
 
@@ -14,16 +16,16 @@ app.get('/api/scrape/:taskId/ics', async (req, res) => {
     const params = req.query;
 
     if (taskId !== 'ders-programi') {
-        return res.status(400).json({ 
-            success: false, 
-            message: 'The ICS format is currently only supported for "ders-programi"' 
-        });
+
+        return res.status(400).json(
+            errorResponse('The ICS format is currently only supported for "ders-programi"')
+        );
     }
 
     const targetScraper = scrapers[taskId];
 
     if (!targetScraper) {
-        return res.status(404).json({ success: false, message: 'Task not found.' });
+        return res.status(404).json(errorResponse('Task not found.'));
     }
 
     try {
@@ -37,25 +39,30 @@ app.get('/api/scrape/:taskId/ics', async (req, res) => {
         res.send(icsString);
     } catch (error) {
         console.error(`[ERROR] (ICS Endpoint):`, error);
-        res.status(500).json({ success: false, message: error.message });
+        res.status(500).json(errorResponse(error.message));
     }
 });
 
 app.get('/api/scrape/:taskId', async (req, res) => {
+
+    const startTime = Date.now(); 
+
     const { taskId } = req.params;
     const params = req.query;
 
     const targetScraper = scrapers[taskId];
 
     if (!targetScraper) {
-        return res.status(404).json({ success: false, message: 'Task not found.' });
+        return res.status(404).json(errorResponse('Task not found.'));
     }
 
     try {
         const data = await runScraper(targetScraper, params); 
-        res.status(200).json({ success: true, data });
+        
+        res.status(200).json(successResponse(data, startTime));
+
     } catch (error) {
-        res.status(500).json({ success: false, message: error.message });
+        res.status(500).json(errorResponse(error.message));
     }
 });
 

--- a/src/utils/response.js
+++ b/src/utils/response.js
@@ -1,0 +1,48 @@
+const config = require('../config');
+const packageJson = require('../../package.json'); 
+
+/**
+ * Creates the output format for successful responses.
+ * @param {Object} data - Data to be sent
+ * @param {Number} startTime - The time the request came
+ * @returns {Object} JSON data
+ */
+function successResponse(data, startTime = Date.now()) {
+    const executionTime = Date.now() - startTime;
+
+    return {
+        success: true,
+        meta: {
+            api_version: packageJson.version,
+            timestamp: new Date().toISOString(),
+            source_url: config.eyotek_url,
+            date_format: config.EYOTEK_DATE_FORMAT || "DD.MM.YYYY",
+            execution_time_ms: executionTime
+        },
+        data: data
+    };
+}
+
+/**
+ * Creates the output format for error responses.
+ * @param {String} message - Error message
+ * @returns {Object} JSON error
+ */
+function errorResponse(message) {
+    return {
+        success: false,
+        meta: {
+            api_version: packageJson.version,
+            timestamp: new Date().toISOString(),
+            source_url: config.eyotek_url
+        },
+        error: {
+            message: message
+        }
+    };
+}
+
+module.exports = {
+    successResponse,
+    errorResponse
+};


### PR DESCRIPTION
This PR appends the `meta` JSON block to the API output.


Here is how its looks:

<details>
    <summary>Successful Output</summary>

```json
{
  "success": true,
  "meta": {
    "api_version": "1.6.0",
    "timestamp": "2026-05-03T14:53:37.380Z",
    "source_url": "xyz.eyotek.com",
    "date_format": "M/D/YYYY",
    "execution_time_ms": 7552
  },
  "data": { null }
}
```

</details>

<details>
    <summary>Error Output</summary>

```json
{
  "success": false,
  "meta": {
    "api_version": "1.6.0",
    "timestamp": "2026-05-03T15:14:58.217Z",
    "source_url": "xyz.eyotek.com"
  },
  "error": {
    "message": "Task not found."
  }
}
```

</details>

