### PR TITLE
refactor(api): make the dates in the same format in all outputs

### DIFF
--- a/src/config.js.example
+++ b/src/config.js.example
@@ -13,5 +13,6 @@ module.exports = {
     PUPPETEER_EXECUTABLE_PATH: '/Applications/Chromium.app/Contents/MacOS/Chromium',
     COOKIES_PATH: './cookies.json',
 
-    EYOTEK_DATE_FORMAT: 'DD.MM.YYYY' 
+    EYOTEK_DATE_FORMAT: 'DD.MM.YYYY',
+    API_DATE_FORMAT: 'YYYY-MM-DD'
 };

--- a/src/scrapers/odevler.js
+++ b/src/scrapers/odevler.js
@@ -60,9 +60,9 @@ module.exports = {
             if (!tarihMetni) return '';
             
             const parseEdilmis = dayjs(tarihMetni, config.EYOTEK_DATE_FORMAT);
+            const apiFormat = config.API_DATE_FORMAT || 'YYYY-MM-DD';
             
-            // convert to YYYY-MM-DD
-            return parseEdilmis.isValid() ? parseEdilmis.format('YYYY-MM-DD') : tarihMetni;
+            return parseEdilmis.isValid() ? parseEdilmis.format(apiFormat) : tarihMetni;
         };
 
         hamVeri.liste = hamVeri.liste.map(odev => {

--- a/src/scrapers/yemekMenu.js
+++ b/src/scrapers/yemekMenu.js
@@ -1,6 +1,9 @@
-
 const dayjs = require('dayjs');
+const customParseFormat = require('dayjs/plugin/customParseFormat');
+dayjs.extend(customParseFormat);
+
 const config = require('../config');
+
 module.exports = {
     id: 'yemek',
     url: `https://${config.eyotek_url}/v1/Pages/Student/parent-food-menu`,
@@ -8,14 +11,18 @@ module.exports = {
     scrape: async (page, params) => {
 
         if (params && params.date) {
+            const apiFormat = config.API_DATE_FORMAT || 'YYYY-MM-DD';
+            
+            const girilenTarih = dayjs(params.date, apiFormat);
+            
+            // convert to eyotek date format
+            const hedefTarih = girilenTarih.format(config.EYOTEK_DATE_FORMAT);
 
-            const hedefTarih = dayjs(params.date).format(config.EYOTEK_DATE_FORMAT);
-
-            if (hedefTarih === 'Invalid Date') {
-                throw new Error("Invalid date format. Example: 2026-04-10");
+            if (!girilenTarih.isValid() || hedefTarih === 'Invalid Date') {
+                throw new Error(`Invalid date format. Expected format: ${apiFormat}`);
             }
             
-            console.log(`📅 Date: ${params.date}`);
+            console.log(`[INFO] (scraper.yemekMenu): Requested Date: ${params.date} -> Eyotek Date: ${hedefTarih}`);
 
             await page.waitForSelector('#txtHistory');
 
@@ -30,7 +37,7 @@ module.exports = {
                 input.dispatchEvent(new Event('change', { bubbles: true }));
             }, hedefTarih);
 
-            console.log('⏳ Waiting for table update...');
+            console.log(`[INFO] (scraper.yemekMenu): Waiting for menu table update`);
 
             try {
                 await page.waitForFunction((eskiHTML) => {
@@ -39,9 +46,9 @@ module.exports = {
                     return guncelHTML !== eskiHTML;
                 }, { timeout: 10000 }, eskiTabloHTML);
 
-                console.log('✅ Table updated!');
+                console.log(`[INFO] (scraper.yemekMenu): Table updated`);
             } catch (error) {
-                console.log('⚠️ The table was not updated (the same data was received or a timeout occurred).');
+                console.log(`[ERROR] (scraper.yemekMenu): The table was not updated (the same data was received or a timeout occurred)`);
             }
 
             await new Promise(r => setTimeout(r, 500));

--- a/src/utils/response.js
+++ b/src/utils/response.js
@@ -16,7 +16,7 @@ function successResponse(data, startTime = Date.now()) {
             api_version: packageJson.version,
             timestamp: new Date().toISOString(),
             source_url: config.eyotek_url,
-            date_format: config.EYOTEK_DATE_FORMAT || "DD.MM.YYYY",
+            date_format: config.API_DATE_FORMAT || "YYYY-MM-DD",
             execution_time_ms: executionTime
         },
         data: data


### PR DESCRIPTION
This PR adds a new config key (`API_DATE_FORMAT`) to ensure that the dates found in API outputs are standardized and customizable, and applies this to the entire project.